### PR TITLE
Fix download URL, switch to .xz

### DIFF
--- a/scripts/patch_gmp.sh
+++ b/scripts/patch_gmp.sh
@@ -8,30 +8,30 @@ __exists() {
 
 cd gmp
 
+gmptar=gmp-6.1.2.tar.xz
 get="fetch";
-! __exists fetch && get="curl -OL";
+! __exists fetch && get="curl -o $gmptar -L";
 
-if [ ! -f gmp-6.1.2.tar.bz2 ];
+if [ ! -f $gmptar ];
 then
-    $get ftp://ftp.gmplib.org/pub/gmp-6.1.2/gmp-6.1.2.tar.bz2
+    $get https://gmplib.org/download/gmp/$gmptar
 fi
 
 
-sum=`openssl sha1 gmp-6.1.2.tar.bz2 | awk -F' ' '{print $2}'`
+sum=`openssl sha1 $gmptar | awk -F' ' '{print $2}'`
 
-if [[ $sum != "366ded6a44cd108ba6b3f5b9a252eab3f3a95cdf" ]];
+if [[ $sum != "9dc6981197a7d92f339192eea974f5eca48fcffe" ]];
 then
-    echo ''
-    echo '=========================================='
-    echo 'ERROR: could not verify gmp-6.1.2.tar.bz2;'
-    echo 'Downloaded over untrusted channel (non-https)'
-    echo '=========================================='
+    echo ""
+    echo "=========================================="
+    echo "ERROR: could not verify $gmptar;"
+    echo "=========================================="
     exit;
 fi
 
-echo 'gmp-6.1.2.tar.bz2 downloaded and verified sha1 signature'
+echo "$gmptar downloaded and verified sha1 signature"
 
-tar xf gmp-6.1.2.tar.bz2
+tar xf $gmptar
 
 cd gmp-6.1.2
 patch -p 1 < ../gmp-6.1.2.patch


### PR DESCRIPTION
This is a proposed fix for #15.

The FTP download URL no longer works. I've switched it to the official upstream https download.

Some further minor changes:
* curl -O seems to have trouble with this server, so I passed the filename via -o
* Changed from .tar.bz2 to the smaller .tar.xz
* Removed note about insecure transport (it's https after all)
* Put filename in a variable